### PR TITLE
Feature/request-headers

### DIFF
--- a/src/main/java/org/example/TCPListener.java
+++ b/src/main/java/org/example/TCPListener.java
@@ -4,15 +4,13 @@ import org.example.request.Request;
 import org.example.request.RequestParser;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.nio.charset.StandardCharsets;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
 
 /**
- * TCP server that listens for client connections and processes incoming data line by line.
+ * TCP server that listens for client connections and processes HTTP requests.
+ * Parses incoming HTTP request lines and headers, then outputs the parsed information.
+ * Uses RequestParser for incremental parsing of HTTP request data.
  */
 public class TCPListener {
 
@@ -20,6 +18,8 @@ public class TCPListener {
 
     /**
      * Main server loop that accepts client connections on port 9001.
+     * For each connection, parses the HTTP request and prints the request line
+     * (method, target, version) and all headers to standard output.
      *
      * @param args command line arguments (unused)
      * @throws IOException if the server socket cannot be created or bound
@@ -37,6 +37,10 @@ public class TCPListener {
                         System.out.println("- Method: " + request.getRequestLine().method());
                         System.out.println("- Target: " + request.getRequestLine().requestTarget());
                         System.out.println("- Version: " + request.getRequestLine().httpVersion());
+                        System.out.println("Headers:");
+                        for (String key : request.getHeaders().getHeaderMap().keySet()) {
+                            System.out.println("- " + key + ": " + request.getHeaders().getValue(key));
+                        }
                     }
                 } catch (IOException e) {
                     System.err.println("Error handling client connection: " + e.getMessage());

--- a/src/main/java/org/example/chunkReader/ChunkReader.java
+++ b/src/main/java/org/example/chunkReader/ChunkReader.java
@@ -15,7 +15,7 @@ public class ChunkReader extends InputStream {
     /**
      * Creates a new chunkReader from a string.
      *
-     * @param data the string data to read from
+     * @param data            the string data to read from
      * @param numBytesPerRead maximum bytes to read per operation
      * @throws IllegalArgumentException if numBytesPerRead is less than 1
      */

--- a/src/main/java/org/example/chunkReader/ChunkReader.java
+++ b/src/main/java/org/example/chunkReader/ChunkReader.java
@@ -6,7 +6,7 @@ import java.io.InputStream;
 /**
  * A custom InputStream implementation that reads data in controlled chunks.
  */
-public class chunkReader extends InputStream {
+public class ChunkReader extends InputStream {
 
     private final byte[] data;
     private final int numBytesPerRead;
@@ -19,7 +19,7 @@ public class chunkReader extends InputStream {
      * @param numBytesPerRead maximum bytes to read per operation
      * @throws IllegalArgumentException if numBytesPerRead is less than 1
      */
-    public chunkReader(String data, int numBytesPerRead) {
+    public ChunkReader(String data, int numBytesPerRead) {
 
         if (numBytesPerRead < 1) {
             throw new IllegalArgumentException("numBytesPerRead must be at least 1, got: " + numBytesPerRead);

--- a/src/main/java/org/example/headers/Headers.java
+++ b/src/main/java/org/example/headers/Headers.java
@@ -1,0 +1,154 @@
+package org.example.headers;
+
+import org.example.request.RequestParser;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Represents HTTP headers and provides functionality to parse HTTP header data.
+ * This class can incrementally parse header data from byte arrays, maintaining
+ * state between parsing calls to handle partial data efficiently.
+ *
+ * Headers are parsed according to HTTP/1.1 specification, where each header line
+ * consists of a field name followed by a colon, optional whitespace, field value,
+ * and terminated by CRLF. Multiple headers with the same name are combined with
+ * comma separation.
+ */
+public class Headers {
+    private Map<String, String> headerMap;
+    private boolean isDone;
+
+    /**
+     * Creates a new Headers instance initialized with an empty header map
+     * and ready to begin parsing.
+     */
+    public Headers() {
+        this.headerMap = new HashMap<>();
+        this.isDone = false;
+    }
+
+    /**
+     * Parses HTTP header data from the provided byte array.
+     * Continues parsing until all headers are consumed or incomplete data is encountered.
+     * Parsing is complete when an empty line (CRLF only) is found, indicating the end
+     * of the header section.
+     *
+     * @param data the byte array containing HTTP header data to parse
+     * @return the total number of bytes consumed from the input data, or -1 if more data is needed
+     * @throws IOException if the header data is malformed or contains invalid syntax
+     */
+    public int parse(byte[] data) throws IOException {
+        int totalBytesParsed = 0;
+        while (!this.isDone) {
+            int result = parseSingle(data, totalBytesParsed);
+
+            if (result == -1) {
+                break;
+            }
+
+            totalBytesParsed += result;
+        }
+        return totalBytesParsed;
+    }
+
+    /**
+     * Parses a single HTTP header line from the provided byte array starting at the given position.
+     * Handles header field validation, duplicate header combination, and end-of-headers detection.
+     *
+     * @param data the byte array containing HTTP header data
+     * @param position the starting position in the byte array to begin parsing
+     * @return the number of bytes consumed for this header line, or -1 if incomplete data
+     * @throws IOException if the header format is invalid, contains illegal characters,
+     *                     or has improper spacing around the colon separator
+     */
+    public int parseSingle(byte[] data, int position) throws IOException {
+        int crlfIndex = RequestParser.findCRLF(data, position);
+
+        if (crlfIndex == -1) {
+            return -1;
+        }
+
+        if (crlfIndex == position) {
+            this.isDone = true;
+            return 2;
+        }
+
+        int separatorIndex = position;
+
+        for (int i = position; i < data.length - 1; i++) {
+            if (data[i] == ':' && data[i - 1] == ' ') {
+                throw new IOException("Invalid spacing in headers at byte index: " + i);
+            } else if (data[i] == ':') {
+                separatorIndex = i;
+                break;
+            }
+        }
+
+        if (separatorIndex == position) {
+            return -1;
+        }
+
+        String key = new String(data, position, separatorIndex - position, StandardCharsets.UTF_8);
+        key =  key.trim().toLowerCase();
+        String value = new String(data, separatorIndex + 1, crlfIndex - (separatorIndex + 1), StandardCharsets.UTF_8);
+        value = value.trim();
+
+        for (char c : key.toCharArray()) {
+            if (!isValidHeaderChar(c)) {
+                throw new IOException("Invalid character in header name: " + c);
+            }
+        }
+
+        if (headerMap.containsKey(key)) {
+            String combinedValue = headerMap.get(key) + ", " + value;
+            headerMap.put(key, combinedValue);
+        } else {
+            headerMap.put(key, value);
+        }
+
+        return crlfIndex + 2;
+    }
+
+    /**
+     * Returns the complete header map containing all parsed headers.
+     * Header names are stored in lowercase, and duplicate headers are combined with comma separation.
+     *
+     * @return a Map containing header names as keys and header values as values
+     */
+    public Map<String, String> getHeaderMap() {
+        return this.headerMap;
+    }
+
+    /**
+     * Retrieves the value for a specific header by name.
+     * Header name lookup is case-insensitive as names are stored in lowercase.
+     *
+     * @param key the header name to look up
+     * @return the header value, or null if the header is not present
+     */
+    public String getValue(String key) {
+        return this.headerMap.get(key);
+    }
+
+    /**
+     * Checks if header parsing is complete.
+     * Parsing is considered done when an empty line (CRLF only) is encountered,
+     * indicating the end of the HTTP header section.
+     *
+     * @return true if all headers have been parsed, false otherwise
+     */
+    public boolean isDone() {
+        return this.isDone;
+    }
+
+
+    private boolean isValidHeaderChar(char c) {
+        String validCharacters = "!#$%&'*+-.^_`|~";
+        if (Character.isLetterOrDigit(c)) return true;
+        else return validCharacters.contains(String.valueOf(c));
+    }
+
+}

--- a/src/main/java/org/example/headers/Headers.java
+++ b/src/main/java/org/example/headers/Headers.java
@@ -11,7 +11,7 @@ import java.util.Map;
  * Represents HTTP headers and provides functionality to parse HTTP header data.
  * This class can incrementally parse header data from byte arrays, maintaining
  * state between parsing calls to handle partial data efficiently.
- *
+ * <p>
  * Headers are parsed according to HTTP/1.1 specification, where each header line
  * consists of a field name followed by a colon, optional whitespace, field value,
  * and terminated by CRLF. Multiple headers with the same name are combined with
@@ -58,7 +58,7 @@ public class Headers {
      * Parses a single HTTP header line from the provided byte array starting at the given position.
      * Handles header field validation, duplicate header combination, and end-of-headers detection.
      *
-     * @param data the byte array containing HTTP header data
+     * @param data     the byte array containing HTTP header data
      * @param position the starting position in the byte array to begin parsing
      * @return the number of bytes consumed for this header line, or -1 if incomplete data
      * @throws IOException if the header format is invalid, contains illegal characters,
@@ -92,7 +92,7 @@ public class Headers {
         }
 
         String key = new String(data, position, separatorIndex - position, StandardCharsets.UTF_8);
-        key =  key.trim().toLowerCase();
+        key = key.trim().toLowerCase();
         String value = new String(data, separatorIndex + 1, crlfIndex - (separatorIndex + 1), StandardCharsets.UTF_8);
         value = value.trim();
 

--- a/src/main/java/org/example/request/Request.java
+++ b/src/main/java/org/example/request/Request.java
@@ -17,7 +17,6 @@ public class Request {
     private final Headers headers;
 
 
-
     /**
      * Represents the current state of the HTTP request parser.
      */

--- a/src/main/java/org/example/request/Request.java
+++ b/src/main/java/org/example/request/Request.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 public class Request {
     RequestLine requestLine;
     private Status status;
-    private Headers headers;
+    private final Headers headers;
 
 
 

--- a/src/main/java/org/example/request/Request.java
+++ b/src/main/java/org/example/request/Request.java
@@ -1,25 +1,29 @@
 package org.example.request;
 
-import java.io.IOException;
+import org.example.headers.Headers;
 
-import static org.example.request.RequestParser.parseRequestLine;
+import java.io.IOException;
 
 /**
  * Represents an HTTP request.
  * This class can incrementally parse HTTP request data from byte streams,
  * maintaining parsing state between calls to handle partial data.
- *
- * The parser progresses through states: INITIALISED → DONE
- * Currently supports parsing the HTTP request line only.
+ * The parser progresses through states: INITIALISED → PARSING_HEADERS → DONE
+ * Supports parsing both the HTTP request line and headers.
  */
 public class Request {
     RequestLine requestLine;
     private Status status;
+    private Headers headers;
+
+
+
     /**
      * Represents the current state of the HTTP request parser.
      */
     public enum Status {
         INITIALISED,
+        PARSING_HEADERS,
         DONE
     }
 
@@ -28,6 +32,7 @@ public class Request {
      */
     public Request() {
         this.status = Status.INITIALISED;
+        this.headers = new Headers();
     }
 
     /**
@@ -41,19 +46,40 @@ public class Request {
      */
     public int parse(byte[] data) throws IOException {
 
-        if (this.status == Status.DONE) {
-            return 0;
+        switch (this.status) {
+            case INITIALISED:
+                RequestLineParseResult result = RequestParser.parseRequestLine(data);
+                if (result.getRequestLine() == null) {
+                    return 0;
+                }
+                this.requestLine = result.getRequestLine();
+                this.status = Status.PARSING_HEADERS;
+
+                int headerBytes = this.headers.parse(result.getRestOfMessage());
+
+                if (this.headers.isDone()) {
+                    this.status = Status.DONE;
+                }
+
+                if (headerBytes == -1) {
+                    return result.getBytesConsumed();
+                }
+
+                return result.getBytesConsumed() + headerBytes;
+            case PARSING_HEADERS:
+                headerBytes = this.headers.parse(data);
+                if (this.headers.isDone()) {
+                    this.status = Status.DONE;
+                }
+                if (headerBytes == -1) {
+                    return 0;
+                }
+                return headerBytes;
+            case DONE:
+                return 0;
+            default:
+                throw new IllegalStateException("Invalid parsing state: " + this.status);
         }
-
-        RequestLineParseResult result = RequestParser.parseRequestLine(data);
-
-        if (result.getRequestLine() == null) {
-            return 0;
-        }
-
-        this.requestLine = result.getRequestLine();
-        this.status = Status.DONE;
-        return result.getBytesConsumed();
     }
 
     /**
@@ -69,14 +95,22 @@ public class Request {
     /**
      * Returns the current parsing status of this Request.
      *
-     * @return the current Status (INITIALISED or DONE)
+     * @return the current Status (INITIALISED, PARSING_HEADERS, or DONE)
      */
     public Status getStatus() {
         return this.status;
     }
 
-
-
+    /**
+     * Returns the parsed HTTP headers.
+     * The Headers object contains all header field-value pairs parsed from the request,
+     * with header names normalized to lowercase and duplicate headers combined.
+     *
+     * @return the Headers object containing parsed HTTP headers
+     */
+    public Headers getHeaders() {
+        return this.headers;
+    }
 }
 
 

--- a/src/main/java/org/example/request/RequestLine.java
+++ b/src/main/java/org/example/request/RequestLine.java
@@ -3,8 +3,9 @@ package org.example.request;
 /**
  * Represents the first line of an HTTP request containing the method, target, and version.
  *
- * @param method the HTTP method (e.g., "GET", "POST", "PUT", "DELETE")
+ * @param method        the HTTP method (e.g., "GET", "POST", "PUT", "DELETE")
  * @param requestTarget the request target path (e.g., "/", "/coffee", "/api/users")
- * @param httpVersion the HTTP version number (e.g., "1.1" for HTTP/1.1)
+ * @param httpVersion   the HTTP version number (e.g., "1.1" for HTTP/1.1)
  */
-public record RequestLine(String method, String requestTarget, String httpVersion) {}
+public record RequestLine(String method, String requestTarget, String httpVersion) {
+}

--- a/src/main/java/org/example/request/RequestLineParseResult.java
+++ b/src/main/java/org/example/request/RequestLineParseResult.java
@@ -1,25 +1,55 @@
 package org.example.request;
 
+/**
+ * Represents the result of parsing an HTTP request line.
+ * Contains the parsed RequestLine, any remaining unparsed data, and the number of bytes consumed.
+ * This class is used by RequestParser to return both the parsing result and information
+ * needed for continued parsing of the remaining HTTP request data.
+ */
 public class RequestLineParseResult {
     private final RequestLine requestLine;
-    private final String restOfMessage;
+    private final byte[] restOfMessage;
     private final int bytesConsumed;
 
 
-    public RequestLineParseResult(RequestLine requestLine, String restOfMessage, int bytesConsumed) {
+    /**
+     * Creates a new RequestLineParseResult.
+     *
+     * @param requestLine the parsed RequestLine, or null if parsing was incomplete
+     * @param restOfMessage the remaining unparsed data after the request line
+     * @param bytesConsumed the number of bytes consumed from the original input during parsing
+     */
+    public RequestLineParseResult(RequestLine requestLine, byte[] restOfMessage, int bytesConsumed) {
         this.requestLine = requestLine;
         this.restOfMessage = restOfMessage;
         this.bytesConsumed = bytesConsumed;
     }
 
+    /**
+     * Returns the parsed HTTP request line.
+     *
+     * @return the RequestLine object, or null if parsing was incomplete
+     */
     public RequestLine getRequestLine() {
         return requestLine;
     }
 
-    public String getRestOfMessage() {
+    /**
+     * Returns the remaining unparsed data after the request line.
+     * This data typically contains HTTP headers and possibly a message body.
+     *
+     * @return byte array containing the rest of the HTTP message
+     */
+    public byte[] getRestOfMessage() {
         return restOfMessage;
     }
 
+    /**
+     * Returns the number of bytes consumed from the original input during request line parsing.
+     * This includes the request line content plus the CRLF terminator.
+     *
+     * @return the number of bytes consumed
+     */
     public int getBytesConsumed() {
         return bytesConsumed;
     }

--- a/src/main/java/org/example/request/RequestLineParseResult.java
+++ b/src/main/java/org/example/request/RequestLineParseResult.java
@@ -15,7 +15,7 @@ public class RequestLineParseResult {
     /**
      * Creates a new RequestLineParseResult.
      *
-     * @param requestLine the parsed RequestLine, or null if parsing was incomplete
+     * @param requestLine   the parsed RequestLine, or null if parsing was incomplete
      * @param restOfMessage the remaining unparsed data after the request line
      * @param bytesConsumed the number of bytes consumed from the original input during parsing
      */

--- a/src/main/java/org/example/request/RequestParser.java
+++ b/src/main/java/org/example/request/RequestParser.java
@@ -69,19 +69,20 @@ public class RequestParser {
     public static RequestLineParseResult parseRequestLine(byte[] rawData) throws IOException {
 
         if (rawData == null || rawData.length < 2) {
-            return new RequestLineParseResult(null, "", 0);
+            return new RequestLineParseResult(null, null, 0);
         }
 
         int crlfindex = findCRLF(rawData);
 
         if (crlfindex == -1) {
-            return new RequestLineParseResult(null, "", 0);
+            return new RequestLineParseResult(null, null, 0);
         }
 
         int bytesConsumed = crlfindex + 2;
 
         String requestLine = new String(rawData, 0, crlfindex, StandardCharsets.UTF_8);
-        String restOfMessage = new String(rawData, bytesConsumed, rawData.length - bytesConsumed, StandardCharsets.UTF_8);
+        byte[] restOfMessage = new byte[rawData.length - bytesConsumed];
+        System.arraycopy(rawData, bytesConsumed, restOfMessage, 0, rawData.length - bytesConsumed);
 
         String[] parts = requestLine.split(" ");
 
@@ -122,8 +123,27 @@ public class RequestParser {
      * @param data the byte array to search
      * @return the index of the \r character if CRLF is found, -1 otherwise
      */
-    private static int findCRLF(byte[] data) {
+    public static int findCRLF(byte[] data) {
         for (int i = 0; i < data.length - 1; i++) {
+            if (data[i] == '\r' && data[i + 1] == '\n') {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Searches for the first occurrence of CRLF (\r\n) sequence in a byte array
+     * starting from the specified position.
+     * This overloaded version allows parsing to continue from a specific offset,
+     * useful for parsing multiple lines or continuing from a previous position.
+     *
+     * @param data the byte array to search
+     * @param position the starting position in the byte array to begin searching
+     * @return the index of the \r character if CRLF is found, -1 otherwise
+     */
+    public static int findCRLF(byte[] data, int position) {
+        for (int i = position; i < data.length - 1; i++) {
             if (data[i] == '\r' && data[i + 1] == '\n') {
                 return i;
             }

--- a/src/main/java/org/example/request/RequestParser.java
+++ b/src/main/java/org/example/request/RequestParser.java
@@ -2,8 +2,6 @@ package org.example.request;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Set;
@@ -62,7 +60,7 @@ public class RequestParser {
      *
      * @param rawData the byte array containing HTTP request data to parse
      * @return a RequestLineParseResult containing the parsed RequestLine (or null if incomplete),
-     *         remaining unparsed data, and the number of bytes consumed
+     * remaining unparsed data, and the number of bytes consumed
      * @throws IOException if the request line format is invalid, contains an unsupported method,
      *                     invalid request target, or unsupported HTTP version
      */
@@ -138,7 +136,7 @@ public class RequestParser {
      * This overloaded version allows parsing to continue from a specific offset,
      * useful for parsing multiple lines or continuing from a previous position.
      *
-     * @param data the byte array to search
+     * @param data     the byte array to search
      * @param position the starting position in the byte array to begin searching
      * @return the index of the \r character if CRLF is found, -1 otherwise
      */

--- a/src/test/java/HeadersTests.java
+++ b/src/test/java/HeadersTests.java
@@ -1,4 +1,3 @@
-import org.example.chunkReader.ChunkReader;
 import org.example.headers.Headers;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/HeadersTests.java
+++ b/src/test/java/HeadersTests.java
@@ -1,0 +1,90 @@
+import org.example.chunkReader.ChunkReader;
+import org.example.headers.Headers;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HeadersTests {
+
+    @Test
+    public void TestValidSingleHeader() throws IOException {
+        Headers headers = new Headers();
+        String data = "Host: localhost:9001\r\n\r\n";
+
+        headers.parse(data.getBytes());
+        assertEquals("localhost:9001", headers.getHeaderMap().get("host"));
+    }
+
+    @Test
+    public void TestValidSingleHeaderWithExtraWhitespaces() throws IOException {
+        Headers headers = new Headers();
+        String data = "    Host:        localhost:9001         \r\n\r\n";
+
+        headers.parse(data.getBytes());
+        assertEquals("localhost:9001", headers.getHeaderMap().get("host"));
+    }
+
+    @Test
+    public void Test2ValidHeaders() throws IOException {
+        Headers headers = new Headers();
+        String data = "Host: localhost:9001\r\n";
+        String data2 = "Test: anotherTestHeader\r\n\r\n";
+
+        headers.parse(data.getBytes());
+        headers.parse(data2.getBytes());
+        assertEquals("localhost:9001", headers.getHeaderMap().get("host"));
+        assertEquals("anotherTestHeader", headers.getHeaderMap().get("test"));
+    }
+
+    @Test
+    public void TestValidDone() throws IOException {
+        Headers headers = new Headers();
+        String data = "Host: localhost:9001\r\n";
+        String data2 = "Test: anotherTestHeader\r\n";
+        String data3 = "\r\n";
+
+        headers.parse(data.getBytes());
+        assertFalse(headers.isDone());
+        headers.parse(data2.getBytes());
+        assertFalse(headers.isDone());
+        headers.parse(data3.getBytes());
+        assertTrue(headers.isDone());
+    }
+
+    @Test
+    public void TestValidFieldNameWithCaseInsensitivity() throws IOException {
+        Headers headers = new Headers();
+        String data = "HoSt: localhost:9001\r\n\r\n";
+        headers.parse(data.getBytes());
+        assertEquals("localhost:9001", headers.getHeaderMap().get("host"));
+    }
+
+    @Test
+    public void TestValidHeaderWithMultipleValues() throws IOException {
+        Headers headers = new Headers();
+        String data = "Host: localhost:9001\r\n";
+        String data2 = "Host: anotherhost:9002\r\n";
+        String data3 = "Host: anotheranotherhost:9003\r\n\r\n";
+
+        headers.parse(data.getBytes());
+        headers.parse(data2.getBytes());
+        headers.parse(data3.getBytes());
+        assertEquals("localhost:9001, anotherhost:9002, anotheranotherhost:9003", headers.getHeaderMap().get("host"));
+    }
+
+    @Test
+    public void TestInvalidSpacing() throws IOException {
+        Headers headers = new Headers();
+        String data = "Host : localhost:9001\r\n\r\n";
+        assertThrows(IOException.class, () -> headers.parse(data.getBytes()));
+    }
+
+    @Test
+    public void TestInvalidCharactersInFieldName() throws IOException {
+        Headers headers = new Headers();
+        String data = "H@st: localhost:9001\r\n\r\n";
+        assertThrows(IOException.class, () -> headers.parse(data.getBytes()));
+    }
+}

--- a/src/test/java/RequestTests.java
+++ b/src/test/java/RequestTests.java
@@ -1,10 +1,9 @@
-import org.example.chunkReader.chunkReader;
+import org.example.chunkReader.ChunkReader;
 import org.example.request.Request;
 import org.example.request.RequestParser;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.io.StringReader;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -18,7 +17,7 @@ public class RequestTests {
                 "User-Agent: curl/7.81.0\r\n" +
                 "Accept: */*\r\n\r\n";
 
-        chunkReader reader = new chunkReader(raw, 3);
+        ChunkReader reader = new ChunkReader(raw, 3);
         Request request = assertDoesNotThrow(() -> RequestParser.requestFromReader(reader));
         assertNotNull(request);
 
@@ -35,7 +34,7 @@ public class RequestTests {
                 "User-Agent: curl/7.81.0\r\n" +
                 "Accept: */*\r\n\r\n";
 
-        chunkReader reader = new chunkReader(raw, 1);
+        ChunkReader reader = new ChunkReader(raw, 1);
         Request request = assertDoesNotThrow(() -> RequestParser.requestFromReader(reader));
         assertNotNull(request);
 
@@ -52,7 +51,7 @@ public class RequestTests {
                 "User-Agent: curl/7.81.0\r\n" +
                 "Accept: */*\r\n\r\n";
 
-        chunkReader reader = new chunkReader(raw, 200);
+        ChunkReader reader = new ChunkReader(raw, 200);
         Request request = assertDoesNotThrow(() -> RequestParser.requestFromReader(reader));
         assertNotNull(request);
 
@@ -69,13 +68,29 @@ public class RequestTests {
                 "User-Agent: curl/7.81.0\r\n" +
                 "Accept: */*\r\n\r\n";
 
-        chunkReader reader = new chunkReader(raw, 3);
+        ChunkReader reader = new ChunkReader(raw, 3);
         Request request = assertDoesNotThrow(() -> RequestParser.requestFromReader(reader));
         assertNotNull(request);
 
         assertEquals("OPTIONS", request.getRequestLine().method());
         assertEquals("*", request.getRequestLine().requestTarget());
         assertEquals("1.1", request.getRequestLine().httpVersion());
+    }
+
+    @Test
+    void TestRequestWithGoodHeaders() {
+        String data =
+                "GET / HTTP/1.1\r\n" +
+                "Host: localhost:9001\r\n" +
+                "User-Agent: curl/7.81.0\r\n" +
+                "Accept: */*\r\n\r\n";
+
+        ChunkReader reader = new ChunkReader(data, 3);
+        Request request = assertDoesNotThrow(() -> RequestParser.requestFromReader(reader));
+        assertNotNull(request);
+        assertEquals("localhost:9001", request.getHeaders().getValue("host"));
+        assertEquals("curl/7.81.0", request.getHeaders().getValue("user-agent"));
+        assertEquals("*/*", request.getHeaders().getValue("accept"));
     }
 
     @Test
@@ -86,7 +101,7 @@ public class RequestTests {
                 "User-Agent: curl/7.81.0\r\n" +
                 "Accept: */*\r\n\r\n";
 
-        chunkReader reader = new chunkReader(raw, 3);
+        ChunkReader reader = new ChunkReader(raw, 3);
         assertThrows(IOException.class, () -> RequestParser.requestFromReader(reader));
     }
 
@@ -98,7 +113,7 @@ public class RequestTests {
                         "User-Agent: curl/7.81.0\r\n" +
                         "Accept: */*\r\n\r\n";
 
-        chunkReader reader = new chunkReader(raw, 3);
+        ChunkReader reader = new ChunkReader(raw, 3);
         assertThrows(IOException.class, () -> RequestParser.requestFromReader(reader));
     }
 
@@ -110,7 +125,7 @@ public class RequestTests {
                 "User-Agent: curl/7.81.0\r\n" +
                 "Accept: */*\r\n\r\n";
 
-        chunkReader reader = new chunkReader(raw, 3);
+        ChunkReader reader = new ChunkReader(raw, 3);
         assertThrows(IOException.class, () -> RequestParser.requestFromReader(reader));
     }
 
@@ -122,7 +137,7 @@ public class RequestTests {
                 "User-Agent: curl/7.81.0\r\n" +
                 "Accept: */*\r\n\r\n";
 
-        chunkReader reader = new chunkReader(raw, 3);
+        ChunkReader reader = new ChunkReader(raw, 3);
         assertThrows(IOException.class, () -> RequestParser.requestFromReader(reader));
     }
 
@@ -134,7 +149,7 @@ public class RequestTests {
                 "User-Agent: curl/7.81.0\r\n" +
                 "Accept: */*\r\n\r\n";
 
-        chunkReader reader = new chunkReader(raw, 3);
+        ChunkReader reader = new ChunkReader(raw, 3);
         assertThrows(IOException.class, () -> RequestParser.requestFromReader(reader));
     }
 
@@ -146,6 +161,68 @@ public class RequestTests {
                 "User-Agent: curl/7.81.0\r\n" +
                 "Accept: */*\r\n\r\n";
 
-        assertThrows(IllegalArgumentException.class, () -> new chunkReader(raw, -1));
+        assertThrows(IllegalArgumentException.class, () -> new ChunkReader(raw, -1));
     }
+
+    @Test
+    void TestMalformedHeader() {
+        String raw =
+                "GET / HTTP/1.1\r\n" +
+                "Host localhost:9001\r\n" +
+                "User-Agent: curl/7.81.0\r\n" +
+                "Accept: */*\r\n\r\n";
+
+        ChunkReader reader = new ChunkReader(raw, 3);
+        assertThrows(IOException.class, () -> RequestParser.requestFromReader(reader));
+    }
+
+    @Test
+    void TestEmptyHeaders() {
+        String raw = "GET / HTTP/1.1\r\n\r\n";
+
+        ChunkReader reader = new ChunkReader(raw, 3);
+        Request request = assertDoesNotThrow(() -> RequestParser.requestFromReader(reader));
+        assertNotNull(request);
+
+        assertEquals("GET", request.getRequestLine().method());
+        assertEquals("/", request.getRequestLine().requestTarget());
+        assertEquals("1.1", request.getRequestLine().httpVersion());
+    }
+
+    @Test
+    void TestDuplicateHeaders() {
+        String raw = "GET / HTTP/1.1\r\n test: test1\r\n test: test2\r\n\r\n";
+
+        ChunkReader reader = new ChunkReader(raw, 3);
+        Request request = assertDoesNotThrow(() -> RequestParser.requestFromReader(reader));
+        assertNotNull(request);
+
+        assertEquals("GET", request.getRequestLine().method());
+        assertEquals("/", request.getRequestLine().requestTarget());
+        assertEquals("1.1", request.getRequestLine().httpVersion());
+        assertEquals("test1, test2", request.getHeaders().getValue("test"));
+    }
+
+    @Test
+    public void TestCaseInsensitiveHeaders() {
+        String raw = "GET / HTTP/1.1\r\n TeSt: success\r\n\r\n";
+
+        ChunkReader reader = new ChunkReader(raw, 3);
+        Request request = assertDoesNotThrow(() -> RequestParser.requestFromReader(reader));
+        assertNotNull(request);
+
+        assertEquals("GET", request.getRequestLine().method());
+        assertEquals("/", request.getRequestLine().requestTarget());
+        assertEquals("1.1", request.getRequestLine().httpVersion());
+        assertEquals("success", request.getHeaders().getValue("test"));
+    }
+
+    @Test
+    public void TestMissingEndOfHeaders() {
+        String raw = "GET / HTTP/1.1\r\n TeSt: success\r\n";
+
+        ChunkReader reader = new ChunkReader(raw, 3);
+        assertThrows(IOException.class, () -> RequestParser.requestFromReader(reader));
+    }
+
 }

--- a/src/test/java/RequestTests.java
+++ b/src/test/java/RequestTests.java
@@ -13,9 +13,9 @@ public class RequestTests {
     void TestGoodRequestLine() {
         String raw =
                 "GET / HTTP/1.1\r\n" +
-                "Host: localhost:9001\r\n" +
-                "User-Agent: curl/7.81.0\r\n" +
-                "Accept: */*\r\n\r\n";
+                        "Host: localhost:9001\r\n" +
+                        "User-Agent: curl/7.81.0\r\n" +
+                        "Accept: */*\r\n\r\n";
 
         ChunkReader reader = new ChunkReader(raw, 3);
         Request request = assertDoesNotThrow(() -> RequestParser.requestFromReader(reader));
@@ -30,9 +30,9 @@ public class RequestTests {
     void TestGoodRequestLineWithPath() {
         String raw =
                 "GET /coffee HTTP/1.1\r\n" +
-                "Host: localhost:9001\r\n" +
-                "User-Agent: curl/7.81.0\r\n" +
-                "Accept: */*\r\n\r\n";
+                        "Host: localhost:9001\r\n" +
+                        "User-Agent: curl/7.81.0\r\n" +
+                        "Accept: */*\r\n\r\n";
 
         ChunkReader reader = new ChunkReader(raw, 1);
         Request request = assertDoesNotThrow(() -> RequestParser.requestFromReader(reader));
@@ -47,9 +47,9 @@ public class RequestTests {
     void TestGoodPOSTRequestWithPath() {
         String raw =
                 "POST /coffee HTTP/1.1\r\n" +
-                "Host: localhost:9001\r\n" +
-                "User-Agent: curl/7.81.0\r\n" +
-                "Accept: */*\r\n\r\n";
+                        "Host: localhost:9001\r\n" +
+                        "User-Agent: curl/7.81.0\r\n" +
+                        "Accept: */*\r\n\r\n";
 
         ChunkReader reader = new ChunkReader(raw, 200);
         Request request = assertDoesNotThrow(() -> RequestParser.requestFromReader(reader));
@@ -64,9 +64,9 @@ public class RequestTests {
     void TestGoodOPTIONSRequestTarget() {
         String raw =
                 "OPTIONS * HTTP/1.1\r\n" +
-                "Host: localhost:9001\r\n" +
-                "User-Agent: curl/7.81.0\r\n" +
-                "Accept: */*\r\n\r\n";
+                        "Host: localhost:9001\r\n" +
+                        "User-Agent: curl/7.81.0\r\n" +
+                        "Accept: */*\r\n\r\n";
 
         ChunkReader reader = new ChunkReader(raw, 3);
         Request request = assertDoesNotThrow(() -> RequestParser.requestFromReader(reader));
@@ -81,9 +81,9 @@ public class RequestTests {
     void TestRequestWithGoodHeaders() {
         String data =
                 "GET / HTTP/1.1\r\n" +
-                "Host: localhost:9001\r\n" +
-                "User-Agent: curl/7.81.0\r\n" +
-                "Accept: */*\r\n\r\n";
+                        "Host: localhost:9001\r\n" +
+                        "User-Agent: curl/7.81.0\r\n" +
+                        "Accept: */*\r\n\r\n";
 
         ChunkReader reader = new ChunkReader(data, 3);
         Request request = assertDoesNotThrow(() -> RequestParser.requestFromReader(reader));
@@ -97,9 +97,9 @@ public class RequestTests {
     void TestInvalidNumPartsInRequestLine() {
         String raw =
                 "/coffee HTTP/1.1\r\n" +
-                "Host: localhost:9001\r\n" +
-                "User-Agent: curl/7.81.0\r\n" +
-                "Accept: */*\r\n\r\n";
+                        "Host: localhost:9001\r\n" +
+                        "User-Agent: curl/7.81.0\r\n" +
+                        "Accept: */*\r\n\r\n";
 
         ChunkReader reader = new ChunkReader(raw, 3);
         assertThrows(IOException.class, () -> RequestParser.requestFromReader(reader));
@@ -121,9 +121,9 @@ public class RequestTests {
     void TestInvalidHTTPVersion() {
         String raw =
                 "GET /coffee HTTP/1.0\r\n" +
-                "Host: localhost:9001\r\n" +
-                "User-Agent: curl/7.81.0\r\n" +
-                "Accept: */*\r\n\r\n";
+                        "Host: localhost:9001\r\n" +
+                        "User-Agent: curl/7.81.0\r\n" +
+                        "Accept: */*\r\n\r\n";
 
         ChunkReader reader = new ChunkReader(raw, 3);
         assertThrows(IOException.class, () -> RequestParser.requestFromReader(reader));
@@ -133,9 +133,9 @@ public class RequestTests {
     void TestInvalidGETRequestTarget() {
         String raw =
                 "GET coffee HTTP/1.1\r\n" +
-                "Host: localhost:9001\r\n" +
-                "User-Agent: curl/7.81.0\r\n" +
-                "Accept: */*\r\n\r\n";
+                        "Host: localhost:9001\r\n" +
+                        "User-Agent: curl/7.81.0\r\n" +
+                        "Accept: */*\r\n\r\n";
 
         ChunkReader reader = new ChunkReader(raw, 3);
         assertThrows(IOException.class, () -> RequestParser.requestFromReader(reader));
@@ -145,9 +145,9 @@ public class RequestTests {
     void TestInvalidOPTIONSRequestTarget() {
         String raw =
                 "OPTIONS coffee HTTP/1.1\r\n" +
-                "Host: localhost:9001\r\n" +
-                "User-Agent: curl/7.81.0\r\n" +
-                "Accept: */*\r\n\r\n";
+                        "Host: localhost:9001\r\n" +
+                        "User-Agent: curl/7.81.0\r\n" +
+                        "Accept: */*\r\n\r\n";
 
         ChunkReader reader = new ChunkReader(raw, 3);
         assertThrows(IOException.class, () -> RequestParser.requestFromReader(reader));
@@ -157,9 +157,9 @@ public class RequestTests {
     void TestInvalidNumBytesInChunkReader() {
         String raw =
                 "OPTIONS coffee HTTP/1.1\r\n" +
-                "Host: localhost:9001\r\n" +
-                "User-Agent: curl/7.81.0\r\n" +
-                "Accept: */*\r\n\r\n";
+                        "Host: localhost:9001\r\n" +
+                        "User-Agent: curl/7.81.0\r\n" +
+                        "Accept: */*\r\n\r\n";
 
         assertThrows(IllegalArgumentException.class, () -> new ChunkReader(raw, -1));
     }
@@ -168,9 +168,9 @@ public class RequestTests {
     void TestMalformedHeader() {
         String raw =
                 "GET / HTTP/1.1\r\n" +
-                "Host localhost:9001\r\n" +
-                "User-Agent: curl/7.81.0\r\n" +
-                "Accept: */*\r\n\r\n";
+                        "Host localhost:9001\r\n" +
+                        "User-Agent: curl/7.81.0\r\n" +
+                        "Accept: */*\r\n\r\n";
 
         ChunkReader reader = new ChunkReader(raw, 3);
         assertThrows(IOException.class, () -> RequestParser.requestFromReader(reader));


### PR DESCRIPTION
Add HTTP Header Parsing

This PR extends the HTTP request parser to add functionality for parsing HTTP headers in addition to request lines. The implementation uses the existing incremental parsing approach and sets up state management and error handling for the new Request states.

  Key Changes:
  - New Headers class - Implements incremental HTTP header parsing
  - Updated Request parsing - Extended state machine to handle request line → headers → *body parsing still needs to be implemented* → done
  - Updated TCPListener - Now displays both request line and header information
  - Updated Test coverage - Added dedicated header tests and updated existing request tests to cover header edge cases
  - Code formatting and documentation - Applied consistent formatting and comprehensive JavaDoc updates

